### PR TITLE
Make object-to-slice conversions consistent

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -30,12 +30,12 @@ pub struct File {
 
 impl File {
     pub fn data(&self) -> &[u8] {
-        unsafe { &*core::ptr::slice_from_raw_parts(self.address as *const u8, self.size as usize) }
+        unsafe { core::slice::from_raw_parts(self.address as *const u8, self.size as usize) }
     }
 
     pub fn data_mut(&mut self) -> &mut [u8] {
         unsafe {
-            &mut *core::ptr::slice_from_raw_parts_mut(self.address as *mut u8, self.size as usize)
+            core::slice::from_raw_parts_mut(self.address as *mut u8, self.size as usize)
         }
     }
 

--- a/src/flanterm.rs
+++ b/src/flanterm.rs
@@ -41,11 +41,11 @@ impl FlantermParams {
         if self.canvas.is_null() {
             return None;
         }
-        Some(unsafe { &*core::ptr::slice_from_raw_parts(self.canvas, self.canvas_size as usize) })
+        Some(unsafe { core::slice::from_raw_parts(self.canvas, self.canvas_size as usize) })
     }
 
     pub const fn canvas_mut(&mut self) -> &mut [u8] {
-        unsafe { &mut *core::ptr::slice_from_raw_parts_mut(self.canvas, self.canvas_size as usize) }
+        unsafe { core::slice::from_raw_parts_mut(self.canvas, self.canvas_size as usize) }
     }
 
     const fn font_size(&self) -> usize {
@@ -58,7 +58,7 @@ impl FlantermParams {
         }
         Some(unsafe {
             Font {
-                font: &*core::ptr::slice_from_raw_parts(self.font as *const u8, self.font_size()),
+                font: core::slice::from_raw_parts(self.font as *const u8, self.font_size()),
                 width: self.font_width,
                 height: self.font_height,
                 spacing: self.font_spacing,

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -51,15 +51,15 @@ impl Framebuffer {
     }
 
     pub fn edid(&self) -> &[u8] {
-        unsafe { &*core::ptr::from_raw_parts(self.edid as _, self.edid_size as usize) }
+        unsafe { core::slice::from_raw_parts(self.edid as _, self.edid_size as usize) }
     }
 
     pub fn as_slice(&self) -> &[u8] {
-        unsafe { &*core::ptr::from_raw_parts(self.address as *const u8, self.size()) }
+        unsafe { core::slice::from_raw_parts(self.address as *const u8, self.size()) }
     }
 
     pub unsafe fn as_slice_mut(&self) -> &mut [u8] {
-        unsafe { &mut *core::ptr::from_raw_parts_mut(self.address as *mut u8, self.size()) }
+        unsafe { core::slice::from_raw_parts_mut(self.address as *mut u8, self.size()) }
     }
 }
 
@@ -73,7 +73,7 @@ pub struct FramebufferRev1 {
 
 impl FramebufferRev1 {
     pub fn modes(&self) -> &[&VideoMode] {
-        unsafe { &*core::ptr::slice_from_raw_parts(self.modes, self.mode_count as usize) }
+        unsafe { core::slice::from_raw_parts(self.modes, self.mode_count as usize) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![no_std]
 #![allow(unused)]
-#![feature(ptr_metadata)]
 
 use core::cell::UnsafeCell;
 

--- a/src/mp/mod.rs
+++ b/src/mp/mod.rs
@@ -42,6 +42,6 @@ impl MpInfo {
 
 impl MpRespData {
     pub const fn cpus(&self) -> &[&MpInfo] {
-        unsafe { &*core::ptr::slice_from_raw_parts(self.cpus as _, self.cpu_count as usize) }
+        unsafe { core::slice::from_raw_parts(self.cpus as _, self.cpu_count as usize) }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -209,7 +209,7 @@ impl Response<FramebufferRespData> {
     /// You can also try [`Self::framebuffers_rev1`] to get framebuffers with multiple modes.
     pub fn framebuffers(&self) -> &[&Framebuffer] {
         unsafe {
-            &*core::ptr::slice_from_raw_parts(
+            core::slice::from_raw_parts(
                 self.framebuffers as _,
                 self.framebuffer_count as usize,
             )
@@ -223,7 +223,7 @@ impl Response<FramebufferRespData> {
             return None;
         }
         Some(unsafe {
-            &*core::ptr::slice_from_raw_parts(
+            core::slice::from_raw_parts(
                 self.framebuffers as _,
                 self.framebuffer_count as usize,
             )
@@ -257,7 +257,7 @@ impl FlantermParamsRequest {
 
 impl FlantermParamsRespData {
     pub fn entries(&self) -> &[&FlantermParams] {
-        unsafe { &*core::ptr::slice_from_raw_parts(self.entries as _, self.entry_count as usize) }
+        unsafe { core::slice::from_raw_parts(self.entries as _, self.entry_count as usize) }
     }
 }
 
@@ -344,7 +344,7 @@ pub struct MemmapRespData {
 
 impl MemmapRespData {
     pub fn entries(&self) -> &[&memmap::Entry] {
-        unsafe { &*core::ptr::slice_from_raw_parts(self.entries as _, self.entry_count as usize) }
+        unsafe { core::slice::from_raw_parts(self.entries as _, self.entry_count as usize) }
     }
 }
 
@@ -412,7 +412,7 @@ pub struct ModulesRespData {
 
 impl ModulesRespData {
     pub fn modules(&self) -> &[&File] {
-        unsafe { &*core::ptr::slice_from_raw_parts(self.modules as _, self.module_count as usize) }
+        unsafe { core::slice::from_raw_parts(self.modules as _, self.module_count as usize) }
     }
 }
 
@@ -529,7 +529,7 @@ pub struct EfiMemmapRespData {
 impl EfiMemmapRespData {
     pub fn memmap(&self) -> &[u8] {
         unsafe {
-            &*core::ptr::slice_from_raw_parts(self.memmap as *const u8, self.memmap_size as usize)
+            core::slice::from_raw_parts(self.memmap as *const u8, self.memmap_size as usize)
         }
     }
 }


### PR DESCRIPTION
This change updates all uses of core::ptr::slice_from_raw_parts and core::ptr::from_raw_parts (which is a nightly-only API) with the stable and more appropriate core::slice::from_raw_parts.

core::ptr::from_raw_parts is a much sharper tool, capable of producing raw trait objects and other non-slice objects but this project only uses it to convert a *const T to a &[T] over the bytes of that object. This use-case is much better served by

    unsafe const fn core::slice::from_raw_parts(data: *const T, len: usize) -> &[T]

This has the added benefit of eliminating the dependency on feature(ptr_metadata), and so this fixes #3